### PR TITLE
[BUG] allow extended scheme

### DIFF
--- a/flask_postgres/__init__.py
+++ b/flask_postgres/__init__.py
@@ -4,4 +4,4 @@ from .ops import create_db
 from .ops import drop_db
 from .types import PostgresUri
 
-__version__ = "0.2.0"
+__version__ = "0.2.1"

--- a/flask_postgres/types.py
+++ b/flask_postgres/types.py
@@ -9,7 +9,7 @@ from flask_postgres.exceptions import UriValidationError
 
 
 _db_regex = re.compile(
-    r'(?:(?P<scheme>[a-z][a-z0-9+\-.]+)://)?'
+    r'(?:(?P<scheme>[a-z][a-z0-9+\-.]+(?:\+[a-z0-9+\-.]+)?)://)?'
     r'(?:(?P<user>[^\s:/]*)'
     r'(?::(?P<password>[^\s/]*))?@)?'
     r'(?P<host>[^\s/:?#]+)'
@@ -156,7 +156,7 @@ class PostgresUri(str):
                 value=uri,
                 issue=f"The URI does not contain a database name."
             )
-        if scheme not in cls._validation_config["allowed_schemes"]:
+        if scheme.split("+")[0] not in cls._validation_config["allowed_schemes"]:
             raise UriValidationError(
                 value=uri,
                 issue=f"Scheme {scheme!r} not in"

--- a/tests/test_types.py
+++ b/tests/test_types.py
@@ -21,6 +21,13 @@ typical_config = AdminUriTestConf(
     expected_admin_uri="postgresql://foo:bar@hello:12345/postgres"
 )
 
+typical_config_w_extended_scheme = AdminUriTestConf(
+    app_config={
+        "SQLALCHEMY_DATABASE_URI": "postgresql+psycopg://foo:bar@hello:12345/world"
+    },
+    expected_admin_uri="postgresql+psycopg://foo:bar@hello:12345/postgres"
+)
+
 typical_config_w_custom_admin = AdminUriTestConf(
     app_config={
         "SQLALCHEMY_DATABASE_URI": "postgresql://foo:bar@hello:12345/world",
@@ -78,6 +85,7 @@ config_with_env_var_that_overrules_sqla_uri = AdminUriTestConf(
 @pytest.mark.parametrize(
     "conf", [
         typical_config,
+        typical_config_w_extended_scheme,
         typical_config_w_custom_admin,
         typical_config_w_custom_admin_w_forward_slash,
         config_with_env_var,


### PR DESCRIPTION
Ran into an issue messing around with a URI that had a scheme of `postgres+psycopg2://`. That should be considered valid and I shouldn't bug the user about it.