### PR TITLE
add db templates; add rich-click as optional

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,8 @@ For apps already setup to use Flask-SQLALchemy, all **Flask-Postgres** configura
 |`FLASK_POSTGRES_CLI_DISALLOWED_ENVS` | `Sequence[str]` (or `str` delimited by `;`) | List of environments where the `flask psql` CLI is disabled from running.<br /><br />(Default behavior is the CLI is never disabled.)
 |`FLASK_POSTGRES_TARGET_DATABASE_URI` | `str` | URL for the Postgres database to be created / initialized / deleted.<br /><br />(Default behavior is to use `SQLALCHEMY_DATABASE_URI`.)
 |`FLASK_POSTGRES_ADMIN_DBNAME` | `str` | Database name to use when connecting to the Postgres server to create or delete another database.<br /><br />It's not recomended that you mess around with this unless you need to.<br /><br />(Default behavior is to replace `{dbname}` with `postgres`.)
+|`FLASK_POSTGRES_DATABASE_TEMPLATE` | `str` | Name of the Postgres database template to use when creating the database.<br /><br />(Default behavior is to not use a custom template at all.)
+|`FLASK_POSTGRES_RICH_CLICK` | `bool` | If true, then use [Rich-Click](https://github.com/ewels/rich-click/) to format `--help`.<br /><br />(Default behavior is `False`, i.e. to not use Rich-Click.)
 
 ### Database connection
 

--- a/flask_postgres/__init__.py
+++ b/flask_postgres/__init__.py
@@ -4,4 +4,4 @@ from .ops import create_db
 from .ops import drop_db
 from .types import PostgresUri
 
-__version__ = "0.2.1"
+__version__ = "0.2.2"

--- a/flask_postgres/cli/main.py
+++ b/flask_postgres/cli/main.py
@@ -164,7 +164,8 @@ def create_db_command(
     return create_db(
         conn=conn,
         dbname=uri.dbname,
-        command_line_mode=True
+        command_line_mode=True,
+        template=config.get("FLASK_POSTGRES_DATABASE_TEMPLATE")
     )
 
 

--- a/flask_postgres/config.py
+++ b/flask_postgres/config.py
@@ -26,7 +26,8 @@ DEFAULT_CONFIG: t.Dict[str, t.Callable[[], t.Any]] = {
     "FLASK_POSTGRES_CLI_DISALLOWED_ENVS": lambda: set(),
     "FLASK_POSTGRES_TARGET_DATABASE_URI": _target_database_uri_default,
     "FLASK_POSTGRES_ADMIN_DBNAME": lambda: "postgres",
-    "FLASK_POSTGRES_DATABASE_TEMPLATE": lambda: None
+    "FLASK_POSTGRES_DATABASE_TEMPLATE": lambda: None,
+    "FLASK_POSTGRES_RICH_CLICK": lambda: False,
 }
 
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -32,7 +32,7 @@ requires-python = ">=3.6"
 [tool.flit.metadata.requires-extra]
 test = [
     "psycopg",
-    "pytest>=6.0.1",
+    "pytest>=6.0.1,<7a0",
     "pytest-cov",
     "pytest-postgresql",
 ]
@@ -42,6 +42,10 @@ doc = [
     "mkdocs-material",
     "mkdocs-macros-plugin",
     "pygments"
+]
+rich = [
+    "rich",
+    "rich-click"
 ]
 
 [tool.flit.entrypoints."flask.commands"]


### PR DESCRIPTION
Choice of default behavior for Rich-Click:

I entertained the idea of: if you have `Rich-Click` in the environment, then just use it. This can make sense if you explicitly installed it yourself as a little shortcut.

However, if you `pip install [somepackage]` other than Rich-Click, and it includes Rich-Click as a dependency, it would violate the principle of least surprise for `flask psql --help` to change its output based on a pip install of another package. Therefore, the default behavior of not using Rich-Click is more intuitive.